### PR TITLE
Uninstall yum-plugin-fastestmirror dirung os upgrade

### DIFF
--- a/files/cloudlinux/pes-events.json
+++ b/files/cloudlinux/pes-events.json
@@ -82681,8 +82681,8 @@
         "set_id": 3975
       },
       "initial_release": {
-        "major_version": 8,
-        "minor_version": 0,
+        "major_version": 7,
+        "minor_version": 7,
         "os_name": "CentOS"
       },
       "is_approved": true,

--- a/files/cloudlinux/pes-events.json
+++ b/files/cloudlinux/pes-events.json
@@ -82662,6 +82662,39 @@
         "minor_version": 1,
         "os_name": "AlmaLinux"
       }
+    },
+    {
+      "action": 1,
+      "arches": [
+        "x86_64",
+        "aarch64"
+      ],
+      "id": 2218,
+      "in_packageset": {
+        "package": [
+          {
+            "module_stream": null,
+            "name": "yum-plugin-fastestmirror",
+            "repository": "base"
+          }
+        ],
+        "set_id": 3975
+      },
+      "initial_release": {
+        "major_version": 8,
+        "minor_version": 0,
+        "os_name": "CentOS"
+      },
+      "is_approved": true,
+      "out_packageset": {
+        "package": [],
+        "set_id": 0
+      },
+      "release": {
+        "major_version": 8,
+        "minor_version": 1,
+        "os_name": "AlmaLinux"
+      }
     }
   ],
   "timestamp": "202108240941Z"


### PR DESCRIPTION
CloudLinux 8 uses dnf without fastestmirror plugin, so we don't need yum-plugin-fastestmirror anymore.